### PR TITLE
Fix derrick assignment in Melting

### DIFF
--- a/data/mp/multiplay/maps/6c-Melting/struct.json
+++ b/data/mp/multiplay/maps/6c-Melting/struct.json
@@ -5646,7 +5646,6 @@
     "structure_603": {
         "modules": 0,
         "name": "A0ResourceExtractor",
-        "player": 0,
         "position": [
             576,
             6336,
@@ -5656,7 +5655,8 @@
             0,
             0,
             0
-        ]
+        ],
+        "startpos": 0
     },
     "structure_604": {
         "modules": 0,


### PR DESCRIPTION
6-player map melting had a player 0 derrick assigned to player 4.

Closes #507.